### PR TITLE
chore: ⬆️ Pin Pow to upstream main fix for ambiguous .pi

### DIFF
--- a/MacIsland.xcodeproj/project.pbxproj
+++ b/MacIsland.xcodeproj/project.pbxproj
@@ -769,8 +769,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/EmergeTools/Pow";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.4;
+				kind = revision;
+				revision = 1b4b1dda28c50b95f0872927ee2226fe8b58950e;
 			};
 		};
 		57680E5D2C678A87000233B9 /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/MacIsland.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MacIsland.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "95ec9a1389c66bcfe4a5a88cfd68bc1b0babc1af4224f594e581d7db21f57324",
+  "originHash" : "f0d4037b316e691fefb0ff41167e80ee122ba1766331e69b36ecf83a7408b0fc",
   "pins" : [
     {
       "identity" : "colorfulx",
@@ -33,8 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/EmergeTools/Pow",
       "state" : {
-        "revision" : "f0d0f3e72d42beaf2b01f1cb798e1b55902814eb",
-        "version" : "1.0.4"
+        "revision" : "1b4b1dda28c50b95f0872927ee2226fe8b58950e"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Pow 1.0.4 (the latest tagged release) fails to compile against the Xcode 26 / Swift 6 toolchain: `error: ambiguous use of 'pi'` in `Sources/Pow/Transitions/Anvil.swift:112`. This blocks the entire project build.
- The fix is already merged to Pow's `main` branch ([commit 1b4b1dd, "Fix ambiguous use of .pi (#83)"](https://github.com/EmergeTools/Pow/commit/1b4b1dda28c50b95f0872927ee2226fe8b58950e), 2026-02-20), but EmergeTools have not cut a 1.0.5 tag.
- Pin the SPM dependency to that revision until a tagged release ships, then switch back to a semver constraint.

## Changes

- `project.pbxproj`: Pow requirement `kind = upToNextMajorVersion; minimumVersion = 1.0.4;` → `kind = revision; revision = 1b4b1dda28c50b95f0872927ee2226fe8b58950e;`
- `Package.resolved`: regenerated by deleting the file and running `xcodebuild -resolvePackageDependencies`.

## Follow-up

Once Pow tags 1.0.5+, revert this pin to `kind = upToNextMajorVersion; minimumVersion = 1.0.5;`.

## Test plan

- [x] `xcodebuild -project MacIsland.xcodeproj -scheme MacIsland -configuration Debug -destination 'platform=macOS' clean build` → **BUILD SUCCEEDED**
- [ ] Reviewer: pull branch, run a clean Debug build in Xcode 26+, confirm green
- [ ] Reviewer: launch the app, smoke-test the Tray drop animation (which is what uses Pow's transitions) to confirm Pow itself still functions at the pinned revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)