### PR TITLE
fix: 🩹 Preserve original filenames for dropped tray files

### DIFF
--- a/MacIsland/AirDrop+View.swift
+++ b/MacIsland/AirDrop+View.swift
@@ -85,7 +85,7 @@ struct AirDropView: View {
 
     func beginDrop(_ providers: [NSItemProvider]) {
         assert(!Thread.isMainThread)
-        guard let urls = providers.interfaceConvert() else { return }
+        guard let urls = providers.stageDroppedFiles() else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             let drop = AirDrop(files: urls)
             drop.begin()

--- a/MacIsland/Ext+FileProvider.swift
+++ b/MacIsland/Ext+FileProvider.swift
@@ -10,46 +10,85 @@ import Foundation
 import UniformTypeIdentifiers
 
 extension NSItemProvider {
-    private func duplicateToOurStorage(_ url: URL?) throws -> URL {
-        guard let url else { throw NSError() }
-        let temp = temporaryDirectory
-            .appendingPathComponent("TemporaryDrop")
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathComponent(url.lastPathComponent)
-        try? FileManager.default.createDirectory(
-            at: temp.deletingLastPathComponent(),
-            withIntermediateDirectories: true
+    /// Stage a dragged file under our temporary drop area, preserving the
+    /// original filename. We try `public.file-url` first because it points
+    /// at the real file on disk, then fall back to a `public.item` file
+    /// representation. We deliberately avoid `public.data`: providers that
+    /// materialize data on demand can synthesize a generic "data" filename,
+    /// which is what was dropping the original name.
+    func stageDroppedFile() -> URL? {
+        // Capture before any callback hop — providers may invalidate state mid-load.
+        let suggestedFileName = suggestedName?.nilIfEmpty
+
+        if hasItemConformingToTypeIdentifier(UTType.fileURL.identifier),
+           let originalURL = loadFileURLSynchronously() {
+            return try? Self.copyToStaging(from: originalURL, fallbackName: suggestedFileName)
+        }
+
+        return loadFileRepresentationSynchronously(
+            typeIdentifier: UTType.item.identifier,
+            fallbackName: suggestedFileName
         )
-        try FileManager.default.copyItem(at: url, to: temp)
-        return temp
     }
 
-    func convertToFilePathThatIsWhatWeThinkItWillWorkWithNotchDrop() -> URL? {
-        var url: URL?
-        let sem = DispatchSemaphore(value: 0)
-        _ = loadObject(ofClass: URL.self) { item, _ in
-            url = try? self.duplicateToOurStorage(item)
-            sem.signal()
-        }
-        sem.wait()
-        if url == nil {
-            loadInPlaceFileRepresentation(
-                forTypeIdentifier: UTType.data.identifier
-            ) { input, _, _ in
-                defer { sem.signal() }
-                url = try? self.duplicateToOurStorage(input)
+    private func loadFileURLSynchronously() -> URL? {
+        var result: URL?
+        let semaphore = DispatchSemaphore(value: 0)
+        loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+            defer { semaphore.signal() }
+            if let data = item as? Data {
+                result = URL(dataRepresentation: data, relativeTo: nil)
+            } else if let url = item as? URL {
+                result = url
             }
-            sem.wait()
         }
-        return url
+        semaphore.wait()
+        return result
+    }
+
+    private func loadFileRepresentationSynchronously(
+        typeIdentifier: String,
+        fallbackName: String?
+    ) -> URL? {
+        var result: URL?
+        let semaphore = DispatchSemaphore(value: 0)
+        // The temp URL is only valid inside the closure; copy out before signaling.
+        _ = loadFileRepresentation(forTypeIdentifier: typeIdentifier) { tempURL, _ in
+            defer { semaphore.signal() }
+            guard let tempURL else { return }
+            result = try? Self.copyToStaging(from: tempURL, fallbackName: fallbackName)
+        }
+        semaphore.wait()
+        return result
+    }
+
+    fileprivate static func copyToStaging(from sourceURL: URL, fallbackName: String?) throws -> URL {
+        let fileName = resolveFileName(from: sourceURL, fallback: fallbackName)
+        let destination = temporaryDirectory
+            .appendingPathComponent("TemporaryDrop")
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent(fileName)
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(at: sourceURL, to: destination)
+        return destination
+    }
+
+    private static func resolveFileName(from sourceURL: URL, fallback: String?) -> String {
+        let sourceName = sourceURL.lastPathComponent
+        if !sourceName.isEmpty { return sourceName }
+        if let fallback { return fallback }
+        return UUID().uuidString
     }
 }
 
 extension [NSItemProvider] {
-    func interfaceConvert() -> [URL]? {
-        let urls = compactMap { provider -> URL? in
-            provider.convertToFilePathThatIsWhatWeThinkItWillWorkWithNotchDrop()
-        }
+    /// Stage all dragged providers. Returns nil and surfaces an alert if any
+    /// provider fails — the drop is treated as atomic.
+    func stageDroppedFiles() -> [URL]? {
+        let urls = compactMap { $0.stageDroppedFile() }
         guard urls.count == count else {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 NSAlert.popError(NSLocalizedString("One or more files failed to load", comment: ""))
@@ -58,4 +97,8 @@ extension [NSItemProvider] {
         }
         return urls
     }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
 }

--- a/MacIsland/TrayDrop.swift
+++ b/MacIsland/TrayDrop.swift
@@ -67,7 +67,7 @@ class TrayDrop: ObservableObject {
     func load(_ providers: [NSItemProvider]) {
         assert(!Thread.isMainThread)
         DispatchQueue.main.asyncAndWait { isLoading += 1 }
-        guard let urls = providers.interfaceConvert() else {
+        guard let urls = providers.stageDroppedFiles() else {
             DispatchQueue.main.asyncAndWait { isLoading -= 1 }
             return
         }


### PR DESCRIPTION
## Summary

- DropTray entries (and AirDrop hand-off) were losing the user's original filename — files showed up as "data" or similar — because the fallback path in `Ext+FileProvider.swift` asked for `UTType.data` (`public.data`). Virtual providers can satisfy that request by materializing a synthesized data blob whose temp URL has no meaningful `lastPathComponent`, which then propagates into `DropItem.fileName`.
- Rewrites the staging pipeline to use representations that preserve the original filename, with `NSItemProvider.suggestedName` as a last-resort fallback.
- Renames the silly `convertToFilePathThatIsWhatWeThinkItWillWorkWithNotchDrop` and `interfaceConvert` to `stageDroppedFile` / `stageDroppedFiles`. Updates both call sites (`TrayDrop.load`, `AirDrop+View.beginDrop`).

## Why it was broken

`loadInPlaceFileRepresentation(forTypeIdentifier: UTType.data.identifier)` is the wrong UTI: `public.data` is a "data blob" type, and providers without an on-disk backing file are free to vend a generic synthesized name when asked for it. The previous `loadObject(ofClass: URL.self)` first-pass also has known flakiness in sandboxed contexts, so the bad fallback got hit a lot.

## What it does now

1. Try `public.file-url` via `loadItem` — points at the real file on disk, so `lastPathComponent` is the original name.
2. Fall back to `public.item` via `loadFileRepresentation` — system writes a temp copy whose `lastPathComponent` is the original name. (Note: `public.item` instead of `public.data` is the key fix.)
3. If both URLs somehow lack a name, fall back to `NSItemProvider.suggestedName`, captured before any callback hop.

## Depends on

#3 (Pow pin). Build doesn't compile against Pow 1.0.4 + Xcode 26 toolchain regardless of this PR. This branch is rebased on top of #3, so it is buildable once #3 lands.

## Test plan

- [x] `xcodebuild -project MacIsland.xcodeproj -scheme MacIsland -configuration Debug -destination 'platform=macOS' build` → **BUILD SUCCEEDED**
- [ ] Reviewer: Drag a file with a recognisable name (e.g. `Report-2026-Q1.pdf`) from Finder onto the tray. Expand the island and confirm the displayed filename matches the source — not "data" / generic.
- [ ] Reviewer: Drag a file from a non-Finder source (e.g. a Safari download in progress, or an attachment from Mail) and confirm the filename still survives.
- [ ] Reviewer: Drag onto the AirDrop region and confirm AirDrop receives the file with the correct name.
- [ ] Reviewer: Drag multiple files at once — all should keep their names; if any one fails, the alert should fire and no items get added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)